### PR TITLE
mTLS/cert naming improvement

### DIFF
--- a/src/hooks/api/useGetCertificate.ts
+++ b/src/hooks/api/useGetCertificate.ts
@@ -1,8 +1,16 @@
 import { type UseMutationOptions, useMutation } from "react-query";
 import { downloadBlob } from "../../lib/downloadBlob";
 
-async function getCertificate(callsign: string) {
+async function getCertificate({
+  callsign,
+  deployment,
+}: {
+  callsign: string;
+  deployment: string;
+}) {
   const jwt = localStorage.getItem("token");
+  const certname = callsign + "_" + deployment;
+
   if (!jwt) {
     throw new Error("No JWT found");
   }
@@ -27,7 +35,7 @@ async function getCertificate(callsign: string) {
   }
 
   const blob = await res.blob();
-  downloadBlob(blob, callsign + ".pfx");
+  downloadBlob(blob, certname + ".pfx");
 
   return blob;
 }
@@ -35,7 +43,7 @@ async function getCertificate(callsign: string) {
 type UseGetCertificateOptions = UseMutationOptions<
   Blob,
   Error,
-  string,
+  { callsign: string; deployment: string },
   unknown
 >;
 

--- a/src/routes/mtls-install.tsx
+++ b/src/routes/mtls-install.tsx
@@ -72,7 +72,7 @@ function MtlsInstallPage() {
 
   const handleDownloadKey = () => {
     if (callsign) {
-      getCertificateMutation.mutate({callsign, deployment});
+      getCertificateMutation.mutate({ callsign, deployment });
     } else {
       toast.error(t("mtlsInstall.callsignNotFound"));
     }

--- a/src/routes/mtls-install.tsx
+++ b/src/routes/mtls-install.tsx
@@ -72,7 +72,7 @@ function MtlsInstallPage() {
 
   const handleDownloadKey = () => {
     if (callsign) {
-      getCertificateMutation.mutate(callsign);
+      getCertificateMutation.mutate({callsign, deployment});
     } else {
       toast.error(t("mtlsInstall.callsignNotFound"));
     }


### PR DESCRIPTION
## User-facing summary
- Downloaded mTLS filename now includes deployment name
-  Allows differentiation between multiple downloaded certificates

## Why It's Good for the Product (Release Goal)
- Improves usability for users with multiple certifications
-  Makes finding the .pfx file easier