### PR TITLE
feat: integrate product pages into main layout with sidebar persistence

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,10 +9,14 @@ jobs:
       - uses: actions/checkout@v5
       - name: Check version tag
         run: |
-          curl -f https://raw.githubusercontent.com/pvarki/react-rasenmaeher-ui-v2//main/package.json -o /tmp/main_package.json || touch /tmp/main_package.json
-          grep '"version":' package.json >/tmp/version.txt
-          grep '"version":' /tmp/main_package.json >/tmp/main_version.txt
-          diff /tmp/main_version.txt /tmp/version.txt && exit 1 || exit 0
+          curl -fL https://raw.githubusercontent.com/pvarki/react-rasenmaeher-ui-v2/main/package.json -o /tmp/main_package.json || touch /tmp/main_package.json
+          PR_VERSION=$(node -p "require('./package.json').version")
+          MAIN_VERSION=$(node -p "require('/tmp/main_package.json').version" 2>/dev/null || echo "")
+          if [ "$PR_VERSION" = "$MAIN_VERSION" ]; then
+            echo "::error::Version $PR_VERSION has not been bumped from main"
+            exit 1
+          fi
+          echo "Version bumped: $MAIN_VERSION -> $PR_VERSION"
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,6 +2,18 @@ on:
   pull_request:
 
 jobs:
+  versiontag:
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v5
+      - name: Check version tag
+        run: |
+          curl -f https://raw.githubusercontent.com/pvarki/react-rasenmaeher-ui-v2//main/package.json -o /tmp/main_package.json || touch /tmp/main_package.json
+          grep '"version":' package.json >/tmp/version.txt
+          grep '"version":' /tmp/main_package.json >/tmp/main_version.txt
+          diff /tmp/main_version.txt /tmp/version.txt && exit 1 || exit 0
+
   test:
     runs-on: ubuntu-latest
     permissions:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-rasenmaeher-ui-v2",
   "private": true,
-  "version": "0.0.0",
+  "version": "2.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -21,7 +21,7 @@ import { User, UserSearch as UserStar } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useLanguage } from "@/hooks/useLanguage";
 import { useGetProductDescriptions } from "@/hooks/api/useGetProductDescriptions";
-import { getCleanProductTitle } from "@/components/home/productUtils";
+import { SidebarProductLink } from "@/components/SidebarProductLink";
 import FeedbackForm from "@/components/Feedbackform";
 
 interface SidebarProps {
@@ -147,23 +147,13 @@ export function Sidebar({ isOpen, onClose, isMobile }: SidebarProps) {
                 className="ml-3 mt-1 space-y-1 border-l border-sidebar-border pl-3"
               >
                 {products.map((product) => (
-                  <Link
-                    data-testid="sidebar-product-link"
-                    data-product-shortname={product.shortname}
+                  <SidebarProductLink
                     key={product.shortname}
-                    to="/product/$shortname"
-                    params={{ shortname: product.shortname }}
-                    onClick={() => {
-                      if (isMobile) onClose();
-                    }}
-                    className={cn(
-                      "block px-3 py-2 text-sm text-sidebar-foreground/80 hover:bg-sidebar-accent/60 rounded-lg transition-colors",
-                      currentProductShortname === product.shortname &&
-                        "bg-sidebar-accent text-sidebar-foreground font-medium",
-                    )}
-                  >
-                    {getCleanProductTitle(product.title)}
-                  </Link>
+                    product={product}
+                    isActive={currentProductShortname === product.shortname}
+                    isMobile={isMobile}
+                    onClose={onClose}
+                  />
                 ))}
               </div>
             )}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -68,7 +68,7 @@ export function Sidebar({ isOpen, onClose, isMobile }: SidebarProps) {
     isAdminToolsSection || isAdminToolsUsers,
   );
 
-  const [deployappsOpen, setDeployappsOpen] = useState(false);
+  const [deployappsOpen, setDeployappsOpen] = useState(isProductPage);
 
   useEffect(() => {
     if (!isAdminToolsSection && !isAdminToolsUsers) {
@@ -79,8 +79,8 @@ export function Sidebar({ isOpen, onClose, isMobile }: SidebarProps) {
   }, [currentPath, currentType, isAdminToolsSection, isAdminToolsUsers]);
 
   useEffect(() => {
-    if (!isProductPage) {
-      setDeployappsOpen(false);
+    if (isProductPage) {
+      setDeployappsOpen(true);
     }
   }, [isProductPage]);
 
@@ -151,9 +151,10 @@ export function Sidebar({ isOpen, onClose, isMobile }: SidebarProps) {
                     data-testid="sidebar-product-link"
                     data-product-shortname={product.shortname}
                     key={product.shortname}
-                    to="#"
+                    to="/product/$shortname"
+                    params={{ shortname: product.shortname }}
                     onClick={() => {
-                      window.open(`/product/${product.shortname}`);
+                      if (isMobile) onClose();
                     }}
                     className={cn(
                       "block px-3 py-2 text-sm text-sidebar-foreground/80 hover:bg-sidebar-accent/60 rounded-lg transition-colors",

--- a/src/components/SidebarProductLink.tsx
+++ b/src/components/SidebarProductLink.tsx
@@ -1,0 +1,58 @@
+import { Link } from "@tanstack/react-router";
+import { ExternalLink } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { getCleanProductTitle } from "@/components/home/productUtils";
+import type { ProductDescription } from "@/hooks/api/useGetProductDescriptions";
+
+interface SidebarProductLinkProps {
+  product: ProductDescription;
+  isActive: boolean;
+  isMobile: boolean;
+  onClose: () => void;
+}
+
+export function SidebarProductLink({
+  product,
+  isActive,
+  isMobile,
+  onClose,
+}: SidebarProductLinkProps) {
+  const title = getCleanProductTitle(product.title);
+  const handleClick = () => {
+    if (isMobile) onClose();
+  };
+
+  if (product.component.type === "link") {
+    return (
+      <a
+        data-testid="sidebar-product-link"
+        data-product-shortname={product.shortname}
+        data-product-external="true"
+        href={product.component.ref}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={handleClick}
+        className="flex items-center justify-between gap-2 px-3 py-2 text-sm text-sidebar-foreground/80 hover:bg-sidebar-accent/60 rounded-lg transition-colors"
+      >
+        <span className="truncate">{title}</span>
+        <ExternalLink className="w-3.5 h-3.5 shrink-0" />
+      </a>
+    );
+  }
+
+  return (
+    <Link
+      data-testid="sidebar-product-link"
+      data-product-shortname={product.shortname}
+      to="/product/$shortname"
+      params={{ shortname: product.shortname }}
+      onClick={handleClick}
+      className={cn(
+        "block px-3 py-2 text-sm text-sidebar-foreground/80 hover:bg-sidebar-accent/60 rounded-lg transition-colors",
+        isActive && "bg-sidebar-accent text-sidebar-foreground font-medium",
+      )}
+    >
+      {title}
+    </Link>
+  );
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -28,13 +28,24 @@ function RootLayoutWrapper() {
 function RootLayout() {
   const location = useLocation();
   const navigate = useNavigate();
-  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(() => {
+    const saved = localStorage.getItem("sidebar-open");
+    if (saved !== null) return saved === "true";
+    return window.innerWidth >= 768;
+  });
   const [mtlsModalOpen, setMtlsModalOpen] = useState(false);
   const { t } = useTranslation();
   const isMobile = useIsMobile();
   const isTablet = useIsTablet();
 
   const { userType, isLoading: userTypeLoading, isValidUser } = useUserType();
+
+  const toggleSidebar = (open: boolean) => {
+    setSidebarOpen(open);
+    if (!isMobile && !isTablet) {
+      localStorage.setItem("sidebar-open", String(open));
+    }
+  };
 
   useEffect(() => {
     const host = window.location.host;
@@ -53,18 +64,8 @@ function RootLayout() {
   }, [userTypeLoading, isValidUser, location.pathname]);
 
   useEffect(() => {
-    if (window.innerWidth >= 768) {
-      setSidebarOpen(true);
-    } else {
-      setSidebarOpen(false);
-    }
-  }, []);
-
-  useEffect(() => {
     if (isMobile || isTablet) {
       setSidebarOpen(false);
-    } else {
-      setSidebarOpen(true);
     }
   }, [location.pathname, isMobile, isTablet]);
 
@@ -74,8 +75,9 @@ function RootLayout() {
     location.pathname === "/mtls-install" ||
     location.pathname === "/callsign-setup" ||
     location.pathname === "/error" ||
-    location.pathname === "/approve-user" ||
-    location.pathname.startsWith("/product/");
+    location.pathname === "/approve-user";
+
+  const isProductPage = location.pathname.startsWith("/product/");
 
   useEffect(() => {
     if (!userTypeLoading && isValidUser) {
@@ -120,29 +122,33 @@ function RootLayout() {
     <div className="h-screen flex flex-col bg-background text-foreground">
       <Header
         sidebarOpen={sidebarOpen}
-        onToggleSidebar={() => setSidebarOpen(!sidebarOpen)}
+        onToggleSidebar={() => toggleSidebar(!sidebarOpen)}
       />
 
       <div className="flex flex-1 min-h-0 overflow-hidden">
         {isMobile && sidebarOpen && (
           <div
             className="fixed inset-0 bg-black/50 z-40 top-16"
-            onClick={() => setSidebarOpen(false)}
+            onClick={() => toggleSidebar(false)}
           />
         )}
 
         <Sidebar
           isOpen={sidebarOpen}
-          onClose={() => setSidebarOpen(false)}
+          onClose={() => toggleSidebar(false)}
           isMobile={isMobile}
         />
 
         <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
-          <main className="flex-1 p-4 md:p-8 overflow-y-auto">
+          <main
+            className={`flex-1 overflow-y-auto ${isProductPage ? "p-2 md:p-4" : "p-4 md:p-8"}`}
+          >
             <Outlet />
           </main>
 
-          <Footer onMtlsInfoClick={() => setMtlsModalOpen(true)} />
+          {!isProductPage && (
+            <Footer onMtlsInfoClick={() => setMtlsModalOpen(true)} />
+          )}
         </div>
       </div>
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -62,7 +62,10 @@ function HomePage() {
       setExitUrl(product.component.ref);
       setExitDialogOpen(true);
     } else {
-      window.open(`/product/${product.shortname}`);
+      navigate({
+        to: "/product/$shortname",
+        params: { shortname: product.shortname },
+      });
     }
   };
 

--- a/src/routes/product.$shortname.$.tsx
+++ b/src/routes/product.$shortname.$.tsx
@@ -10,7 +10,7 @@ import {
   ProductLoading,
   ProductError,
 } from "@/components/product/ProductLoadingStates";
-import { ProductHeader } from "@/components/product/ProductHeader";
+import { ArrowLeft } from "lucide-react";
 import { MarkdownRenderer } from "@/components/product/MarkdownRenderer";
 import { loadRemoteComponent } from "@/components/product/remoteComponentLoader";
 import { useUserType } from "@/hooks/auth/useUserType";
@@ -75,16 +75,6 @@ function ProductPage() {
     }
   }, [product, navigate, productsLoading, products]);
 
-  const handleClose = () => {
-    window.close();
-    // Browsers prevent closing manually opened tabs for security; navigate to home if close failed
-    setTimeout(() => {
-      if (!window.closed) {
-        navigate({ to: "/" });
-      }
-    }, 100);
-  };
-
   if (productsLoading) {
     return <ProductLoading message={t("product.loadingProducts")} />;
   }
@@ -104,43 +94,48 @@ function ProductPage() {
       data-testid="product-page"
       data-product-shortname={shortname}
       data-product-component-type={product.component.type}
-      className="fixed inset-0 z-50 bg-background flex flex-col"
     >
-      <ProductHeader title={product.title} onClose={handleClose} />
-
-      <div className="flex-1 overflow-auto p-4 md:p-8">
-        <div className="max-w-4xl mx-auto">
-          {product.component.type === "component" ? (
-            <Suspense
-              fallback={
-                <div
-                  data-testid="product-remote-loading"
-                  className="text-center space-y-4 py-12 text-2xl font-bold text-foreground"
-                >
-                  {t("product.loadingRemote")}
-                </div>
-              }
+      {product.component.type === "component" ? (
+        <Suspense
+          fallback={
+            <div
+              data-testid="product-remote-loading"
+              className="text-center space-y-4 py-12 text-2xl font-bold text-foreground"
             >
-              <Remote
-                data={instructionsData?.data || {}}
-                meta={{
-                  theme: import.meta.env.VITE_THEME,
-                  callsign: callsign,
-                }}
-                shortname={shortname}
-                onNavigate={navigate}
-              />
-            </Suspense>
-          ) : product.component.type === "markdown" ? (
+              {t("product.loadingRemote")}
+            </div>
+          }
+        >
+          <Remote
+            data={instructionsData?.data || {}}
+            meta={{
+              theme: import.meta.env.VITE_THEME,
+              callsign: callsign,
+            }}
+            shortname={shortname}
+            onNavigate={navigate}
+          />
+        </Suspense>
+      ) : product.component.type === "markdown" ? (
+        <div>
+          <button
+            onClick={() => navigate({ to: "/" })}
+            className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            {t("common.home")}
+          </button>
+          <h1 className="text-2xl font-bold mb-6">{product.title}</h1>
+          <div className="max-w-4xl">
             <MarkdownRenderer
               content={markdownContent}
               isLoading={markdownLoading}
               fallbackTitle={product.title}
               fallbackDescription={product.description}
             />
-          ) : null}
+          </div>
         </div>
-      </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## User-facing summary
- Product pages (e.g. MediaMTX) now render inside the main layout with navbar and sidebar visible
- Product links in sidebar and home page navigate in-app instead of opening new tabs
- Sidebar remembers open/close state across page loads (desktop only)
- Product dropdown in sidebar auto-expands when viewing a product page
- Remote component products get full width without extra wrapper elements

## Why It's Good for the Product (Release Goal)
- Consistent navigation experience — users stay in the app when switching between products
- Sidebar state persistence reduces friction for users who prefer it open or closed
- Full-width product rendering gives federated modules (like MediaMTX) control over their own layout

## Any Other You'd Like to Mention
- Product pages get reduced padding and no footer to maximize space for product content
- Markdown-type products keep the back button and title wrapper